### PR TITLE
back/post-controller-addComments

### DIFF
--- a/back/src/main/java/com/jerem/mdd/controller/AuthController.java
+++ b/back/src/main/java/com/jerem/mdd/controller/AuthController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.jerem.mdd.dto.AuthResponseDto;
-import com.jerem.mdd.dto.LoginRequestDto;
+import com.jerem.mdd.dto.AuthRequestDto;
 import com.jerem.mdd.service.AuthenticationService;
 import com.jerem.mdd.service.DefaultAuthenticationService;
 import com.jerem.mdd.service.UserManagementService;
@@ -45,7 +45,7 @@ public class AuthController {
      * <p>
      * This method authenticates using POST parameters and return back a Json Web Token.
      * 
-     * @param {@link LoginRequestDto} the request DTO.
+     * @param {@link AuthRequestDto} the request DTO.
      * @return {@link AuthResponseDto} the response DTO.
      */
 
@@ -56,7 +56,7 @@ public class AuthController {
                             description = "Successful authentication, returns a token"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized")})
     @PostMapping("/login")
-    public ResponseEntity<AuthResponseDto> login(@RequestBody LoginRequestDto request) {
+    public ResponseEntity<AuthResponseDto> login(@RequestBody AuthRequestDto request) {
         log.debug("@PostMapping(\"/login\")");
         try {
             AuthResponseDto authResponse = authenticationService.authenticate(request);

--- a/back/src/main/java/com/jerem/mdd/controller/PostController.java
+++ b/back/src/main/java/com/jerem/mdd/controller/PostController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.jerem.mdd.dto.CommentRequest;
 import com.jerem.mdd.dto.PostDetailedDto;
 import com.jerem.mdd.dto.PostRequestDto;
 import com.jerem.mdd.dto.PostSummaryDto;
@@ -104,5 +105,25 @@ public class PostController {
         public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
                 postService.deletePost(postId);
                 return ResponseEntity.noContent().build();
+        }
+
+        /**
+         * Add a comment to a post.
+         *
+         * @param postId Post ID.
+         * @return Post details.
+         */
+        @Operation(summary = "Get post by ID",
+                        description = "Retrieve a specific post by its ID with its content.")
+        @ApiResponse(responseCode = "200", description = "Post found")
+        @ApiResponse(responseCode = "400", description = "Bad Request")
+        @ApiResponse(responseCode = "404", description = "Post not found")
+
+        @PostMapping("/{postId}/comments/")
+        public ResponseEntity<PostDetailedDto> addComment(@PathVariable Long postId,
+                        @Valid @RequestBody CommentRequest commentRequest) {
+                return ResponseEntity.status(HttpStatus.CREATED)
+                                .body(postService.addPost(postId, commentRequest));
+
         }
 }

--- a/back/src/main/java/com/jerem/mdd/dto/AuthRequestDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/AuthRequestDto.java
@@ -8,11 +8,11 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 
-public class LoginRequestDto {
+public class AuthRequestDto {
     private String identifier; // Peut être un email ou un username
     private String password;
 
-    public LoginRequestDto(String identifier, String password) {
+    public AuthRequestDto(String identifier, String password) {
         this.identifier = identifier;
         this.password = password;
     }

--- a/back/src/main/java/com/jerem/mdd/dto/CommentDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/CommentDto.java
@@ -6,16 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(description = "Response body containing the post.")
+@Schema(description = "Body containing a comment.")
 public class CommentDto {
 
     private Long id;
 
     private String content;
 
+    @JsonProperty("created_at")
     private Date createdAt;
-    @JsonProperty("user_id")
-    private Long userId;
+    @JsonProperty("author_id")
+    private Long authorId;
     @JsonProperty("post_id")
     private Long postId;
 }

--- a/back/src/main/java/com/jerem/mdd/dto/CommentRequestDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/CommentRequestDto.java
@@ -1,0 +1,14 @@
+package com.jerem.mdd.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request body used to add a comment.")
+public class CommentRequest {
+
+    @Size(max = 5000, message = "The comment is too long")
+    private String content;
+
+}

--- a/back/src/main/java/com/jerem/mdd/dto/ErrorResponseDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/ErrorResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Data;
  */
 @Data
 @AllArgsConstructor
+@Schema(description = "Body containing a standardized error response.")
 public class ErrorResponseDto {
 
 

--- a/back/src/main/java/com/jerem/mdd/dto/PostDetailedDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/PostDetailedDto.java
@@ -16,7 +16,7 @@ public class PostDetailedDto extends PostSummaryDto {
 
     private String content;
 
-    private List<String> comments;
+    private List<CommentDto> comments;
 
 
 }

--- a/back/src/main/java/com/jerem/mdd/dto/PostRequestDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/PostRequestDto.java
@@ -2,6 +2,8 @@ package com.jerem.mdd.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
@@ -12,5 +14,7 @@ public class PostRequestDto {
     @JsonProperty("topic_id")
     private Long topicId;
 
+    @NotBlank
+    @Size(max = 50000, message = "Le contenu de l'article est trop long")
     private String content;
 }

--- a/back/src/main/java/com/jerem/mdd/dto/PostSummaryDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/PostSummaryDto.java
@@ -1,6 +1,5 @@
 package com.jerem.mdd.dto;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;

--- a/back/src/main/java/com/jerem/mdd/mapper/CommentMapper.java
+++ b/back/src/main/java/com/jerem/mdd/mapper/CommentMapper.java
@@ -1,0 +1,35 @@
+package com.jerem.mdd.mapper;
+
+import org.modelmapper.ModelMapper;
+import com.jerem.mdd.dto.CommentDto;
+import com.jerem.mdd.model.Comment;
+
+public class CommentMapper implements Mapper<Comment, CommentDto> {
+    private final ModelMapper modelMapper;
+
+
+    public CommentMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+
+    }
+
+    @Override
+    public CommentDto toDto(Comment comment) {
+        CommentDto commentDto = modelMapper.map(comment, CommentDto.class);
+
+        if (comment.getAuthor() != null) {
+            commentDto.setAuthorId(comment.getAuthor().getId());
+        } else {
+            commentDto.setAuthorId(null);
+        }
+
+        return commentDto;
+    }
+
+    @Override
+    public Comment toEntity(CommentDto dto) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'toEntity'");
+    }
+
+}

--- a/back/src/main/java/com/jerem/mdd/mapper/PostMapper.java
+++ b/back/src/main/java/com/jerem/mdd/mapper/PostMapper.java
@@ -35,6 +35,7 @@ public class PostMapper implements Mapper<Post, PostSummaryDto> {
         postDto.setTopicId(post.getTopic().getId());
 
 
+
         return postDto;
     }
 
@@ -70,6 +71,7 @@ public class PostMapper implements Mapper<Post, PostSummaryDto> {
         postDetailedDto.setCreatedAt(post.getCreatedAt().toString());
         postDetailedDto.setAuthorId(post.getAuthor().getId());
         postDetailedDto.setTopicId(post.getTopic().getId());
+
 
         return postDetailedDto;
 

--- a/back/src/main/java/com/jerem/mdd/model/Comment.java
+++ b/back/src/main/java/com/jerem/mdd/model/Comment.java
@@ -14,10 +14,12 @@ import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Data
 @Table(name = "comments")
+@NoArgsConstructor
 public class Comment {
 
     @Id

--- a/back/src/main/java/com/jerem/mdd/service/AuthenticationService.java
+++ b/back/src/main/java/com/jerem/mdd/service/AuthenticationService.java
@@ -2,7 +2,7 @@ package com.jerem.mdd.service;
 
 import org.springframework.security.authentication.AuthenticationManager;
 import com.jerem.mdd.dto.AuthResponseDto;
-import com.jerem.mdd.dto.LoginRequestDto;
+import com.jerem.mdd.dto.AuthRequestDto;
 
 public interface AuthenticationService {
 
@@ -13,12 +13,11 @@ public interface AuthenticationService {
      * token upon successful authentication with the help of {@link jwtFactory}.
      * </p>
      * 
-     * @param {@link LoginRequestDto} the login request containing the user's identifier and
-     *        password
+     * @param {@link AuthRequestDto} the login request containing the user's identifier and password
      * @return a {@link AuthResponseDto} containing the generated authentication response
      * @throws Exception if authentication fails
      */
-    public AuthResponseDto authenticate(LoginRequestDto request) throws Exception;
+    public AuthResponseDto authenticate(AuthRequestDto request) throws Exception;
 
     public String getAuthenticatedUserEmail();
 

--- a/back/src/main/java/com/jerem/mdd/service/DefaultAuthenticationService.java
+++ b/back/src/main/java/com/jerem/mdd/service/DefaultAuthenticationService.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.dto.AuthResponseDto;
-import com.jerem.mdd.dto.LoginRequestDto;
+import com.jerem.mdd.dto.AuthRequestDto;
 import com.jerem.mdd.model.User;
 import com.jerem.mdd.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ public class DefaultAuthenticationService implements AuthenticationService {
         this.userRepository = userRepository;
     }
 
-    public AuthResponseDto authenticate(LoginRequestDto request) throws Exception {
+    public AuthResponseDto authenticate(AuthRequestDto request) throws Exception {
         User user = userRepository.findByEmail(request.getIdentifier())
                 .orElseGet(() -> userRepository.findByUsername(request.getIdentifier()).orElseThrow(
                         () -> new UsernameNotFoundException("Utilisateur non trouvé")));

--- a/back/src/main/java/com/jerem/mdd/service/PostService.java
+++ b/back/src/main/java/com/jerem/mdd/service/PostService.java
@@ -6,13 +6,16 @@ import java.util.Date;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import com.jerem.mdd.dto.CommentRequest;
 import com.jerem.mdd.dto.PostDetailedDto;
 import com.jerem.mdd.dto.PostRequestDto;
 import com.jerem.mdd.dto.PostSummaryDto;
 import com.jerem.mdd.mapper.PostMapper;
+import com.jerem.mdd.model.Comment;
 import com.jerem.mdd.model.Post;
 import com.jerem.mdd.model.Topic;
 import com.jerem.mdd.model.User;
+import com.jerem.mdd.repository.CommentRepository;
 import com.jerem.mdd.repository.PostRepository;
 import com.jerem.mdd.repository.TopicRepository;
 import com.jerem.mdd.exception.*;
@@ -25,15 +28,18 @@ public class PostService {
     private final PostMapper postMapper;
     private final PostRepository postRepository;
     private final TopicRepository topicRepository;
+    private final CommentRepository commentRepository;
 
     public PostService(AuthenticationService authenticationService,
             UserManagementService userManagementService, PostMapper postMapper,
-            PostRepository postRepository, TopicRepository topicRepository) {
+            PostRepository postRepository, TopicRepository topicRepository,
+            CommentRepository commentRepository) {
         this.authenticationService = authenticationService;
         this.userManagementService = userManagementService;
         this.postMapper = postMapper;
         this.postRepository = postRepository;
         this.topicRepository = topicRepository;
+        this.commentRepository = commentRepository;
     }
 
     public PostSummaryDto createPost(PostRequestDto postRequestDto) {
@@ -77,6 +83,31 @@ public class PostService {
     public void deletePost(Long postId) {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'deletePost'");
+    }
+
+
+    public PostDetailedDto addPost(Long postId, CommentRequest commentRequest) {
+        String authenticatedUserEmail = authenticationService.getAuthenticatedUserEmail();
+
+        User authenticatedUser = userManagementService.getUserEntityByEmail(authenticatedUserEmail)
+                .orElseThrow(() -> new UserNotFoundException("User not found",
+                        "PostService.createPost"));
+
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new PostNotFoundException("Post not found", "PostService.getAllPosts"));
+
+
+        Comment comment = new Comment();
+        comment.setAuthor(authenticatedUser);
+        comment.setContent(commentRequest.getContent());
+        comment.setCreatedAt(Date.from(Instant.now()));
+        comment.setPost(post);
+
+        commentRepository.save(comment);
+        return postMapper.toDetailedDto(post);
+
+
+
     }
 
 }


### PR DESCRIPTION
 - now possible to add a comment to a post
 - like other endpoints, the user/author id could not be sent in request payload, the id of authenticated user is directly retrieved from Spring security Context.
 - constraint on jpa, commentRequestDto are also set