### PR TITLE
update-profile:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .sdkmanrc
 .env-mysql
+.vscode/eclipse-java-google-style.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,11 @@
 {
-
   "java.compile.nullAnalysis.mode": "automatic",
   "java.configuration.updateBuildConfiguration": "automatic",
-
   "[java]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "redhat.java"
   },
-  "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
+  "java.format.settings.url": ".vscode/eclipse-java-google-style.xml",
   "java.format.settings.profile": "GoogleStyle",
   "editor.tabSize": 4
 }

--- a/back/src/main/java/com/jerem/mdd/configuration/AppConfig.java
+++ b/back/src/main/java/com/jerem/mdd/configuration/AppConfig.java
@@ -14,9 +14,9 @@ import com.jerem.mdd.service.JwtTokenProvider;
 import com.jerem.mdd.service.UserManagementService;
 import jakarta.annotation.PostConstruct;
 
-
 /**
- * Configuration class for the application. This class defines beans that will be managed by the
+ * Configuration class for the application. This class defines beans that will
+ * be managed by the
  * Spring application.
  */
 @Configuration
@@ -31,8 +31,10 @@ public class AppConfig {
     }
 
     /**
-     * Defines a JwtTokenProvider bean for handling JSON Web Token (JWT) creation and validation.
-     * Here we uses an HMAC-based JWT factory configured with properties from AppConfigProperties.
+     * Defines a JwtTokenProvider bean for handling JSON Web Token (JWT) creation
+     * and validation.
+     * Here we uses an HMAC-based JWT factory configured with properties from
+     * AppConfigProperties.
      *
      * @param appConfigProperties Configuration properties
      * @return a JwtFactory specific implementation
@@ -43,10 +45,11 @@ public class AppConfig {
     }
 
     /**
-     * Defines a UserManagementService bean that handles user management operations. Here we uses a
+     * Defines a UserManagementService bean that handles user management operations.
+     * Here we uses a
      * UserManagementService implementation : DefaultUserManagementService.
      *
-     * @param userRepository Repository for accessing user data.
+     * @param userRepository  Repository for accessing user data.
      * @param passwordEncoder Encoder for hashing passwords.
      * @return a UserManagementService specific implementation
      */
@@ -55,7 +58,6 @@ public class AppConfig {
             PasswordEncoder passwordEncoder) {
         return new DefaultUserManagementService(userRepository, passwordEncoder);
     }
-
 
     /**
      * Defines a modelMapper bean that handles mapping between entity and dto.

--- a/back/src/main/java/com/jerem/mdd/configuration/SpringSecurityConfig.java
+++ b/back/src/main/java/com/jerem/mdd/configuration/SpringSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import com.jerem.mdd.configuration.filters.JwtDebugFilter;
@@ -21,108 +22,114 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import lombok.extern.slf4j.Slf4j;
 
-
 @Configuration
 @EnableWebSecurity
 @Slf4j
 public class SpringSecurityConfig {
-    private final UserDetailsService userDetailsService;
-    private final JwtTokenProvider jwtTokenProvider;
+        private final UserDetailsService userDetailsService;
+        private final JwtTokenProvider jwtTokenProvider;
 
-    private static final String[] AUTH_WHITELIST =
-            {"/api/auth/login", "/api/auth/register", "/swagger-ui/**", "/v3/api-docs/**"
+        private static final String[] AUTH_WHITELIST = { "/api/auth/login", "/api/auth/register", "/swagger-ui/**",
+                        "/v3/api-docs/**"
 
-            };
+        };
 
-    public SpringSecurityConfig(UserDetailsService userDetailsService,
-            JwtTokenProvider jwtTokenProvider) {
-        this.userDetailsService = userDetailsService;
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
+        public SpringSecurityConfig(UserDetailsService userDetailsService,
+                        JwtTokenProvider jwtTokenProvider) {
+                this.userDetailsService = userDetailsService;
+                this.jwtTokenProvider = jwtTokenProvider;
+        }
 
-    /**
-     * Configures the {@link SecurityFilterChain} bean, overiding default security rules applied to
-     * HTTP requests.
-     * <p>
-     * This configuration: - Disables CSRF protection (may need to be adjusted for specific use
-     * cases). - Permits access to the {@link AUTH_WHITELIST} URL without authentication. - Requires
-     * authentication for all other requests. - Configures Spring Security to act as an OAuth
-     * Ressource Server and enforce jwt authentication
-     * </p>
-     * 
-     * @param http the {@link HttpSecurity} instance used to configure HTTP security
-     * @return the configured {@link SecurityFilterChain} bean
-     * @throws Exception if there is a configuration error
-     */
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http.csrf(AbstractHttpConfigurer::disable)
+        /**
+         * Configures the {@link SecurityFilterChain} bean, overiding default security
+         * rules applied to
+         * HTTP requests.
+         * <p>
+         * This configuration: - Disables CSRF protection (may need to be adjusted for
+         * specific use
+         * cases). - Permits access to the {@link AUTH_WHITELIST} URL without
+         * authentication. - Requires
+         * authentication for all other requests. - Configures Spring Security to act as
+         * an OAuth
+         * Ressource Server and enforce jwt authentication
+         * </p>
+         * 
+         * @param http the {@link HttpSecurity} instance used to configure HTTP security
+         * @return the configured {@link SecurityFilterChain} bean
+         * @throws Exception if there is a configuration error
+         */
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                return http.csrf(AbstractHttpConfigurer::disable)
 
-                .sessionManagement(
-                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.requestMatchers(AUTH_WHITELIST).permitAll()
-                        .anyRequest().authenticated())
-                .addFilterBefore(new JwtDebugFilter(), UsernamePasswordAuthenticationFilter.class)
-                .oauth2ResourceServer((oauth2) -> oauth2.jwt(withDefaults())).build();
-    }
+                                .sessionManagement(
+                                                session -> session
+                                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                                .authorizeHttpRequests(auth -> auth.requestMatchers(AUTH_WHITELIST).permitAll()
+                                                .anyRequest().authenticated())
+                                .addFilterBefore(new JwtDebugFilter(), UsernamePasswordAuthenticationFilter.class)
+                                .oauth2ResourceServer((oauth2) -> oauth2.jwt(withDefaults())).build();
+        }
 
+        /**
+         * This bean is requierd by Spring security and provides a
+         * {@link PasswordEncoder} to use BCrypt
+         * for password encoding.
+         * <p>
+         * BCrypt is a secure hashing algorithm used to protect user passwords in the
+         * database.
+         * </p>
+         * 
+         * @return the {@link PasswordEncoder} bean configured with BCrypt
+         */
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
+        }
 
-    /**
-     * This bean is requierd by Spring security and provides a {@link PasswordEncoder} to use BCrypt
-     * for password encoding.
-     * <p>
-     * BCrypt is a secure hashing algorithm used to protect user passwords in the database.
-     * </p>
-     * 
-     * @return the {@link PasswordEncoder} bean configured with BCrypt
-     */
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+        /**
+         * Get a JwtDecoder from the factory. This bean is requierd by Spring security.
+         * 
+         * @return the configured {@link JwtDecoder} bean
+         * 
+         */
+        @Bean
+        public JwtDecoder JwtDecoder() {
+                return this.jwtTokenProvider.createJwtDecoder();
+        }
 
-    /**
-     * Get a JwtDecoder from the factory. This bean is requierd by Spring security.
-     * 
-     * @return the configured {@link JwtDecoder} bean
-     * 
-     */
-    @Bean
-    public JwtDecoder JwtDecoder() {
-        return this.jwtTokenProvider.createJwtDecoder();
-    }
+        /**
+         * Get a JwtEncoder from the factory. This bean is requierd by Spring security.
+         * 
+         * @return the configured {@link JwtEncoder} bean
+         * 
+         */
+        @Bean
+        public JwtEncoder JwtEncoder() {
+                return this.jwtTokenProvider.createJwtEncoder();
+        }
 
-    /**
-     * Get a JwtEncoder from the factory. This bean is requierd by Spring security.
-     * 
-     * @return the configured {@link JwtEncoder} bean
-     * 
-     */
-    @Bean
-    public JwtEncoder JwtEncoder() {
-        return this.jwtTokenProvider.createJwtEncoder();
-    }
-
-    /**
-     * Configures the Spring Security {@link AuthenticationManager} bean, which is responsible for
-     * authenticating users. This bean is requierd by Spring security.
-     * <p>
-     * </p>
-     * 
-     * @param http the {@link HttpSecurity} instance, required for configuring authentication.
-     * @param passwordEncoder the {@link PasswordEncoder} used to check passwords.
-     * @return the configured {@link AuthenticationManager} bean
-     * @throws Exception if there is a configuration error
-     */
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http,
-            PasswordEncoder passwordEncoder) throws Exception {
-        AuthenticationManagerBuilder authenticationManagerBuilder =
-                http.getSharedObject(AuthenticationManagerBuilder.class);
-        authenticationManagerBuilder.userDetailsService(userDetailsService)
-                .passwordEncoder(passwordEncoder);
-        return authenticationManagerBuilder.build();
-    }
-
+        /**
+         * Configures the Spring Security {@link AuthenticationManager} bean, which is
+         * responsible for
+         * authenticating users. This bean is requierd by Spring security.
+         * <p>
+         * </p>
+         * 
+         * @param http            the {@link HttpSecurity} instance, required for
+         *                        configuring authentication.
+         * @param passwordEncoder the {@link PasswordEncoder} used to check passwords.
+         * @return the configured {@link AuthenticationManager} bean
+         * @throws Exception if there is a configuration error
+         */
+        @Bean
+        public AuthenticationManager authenticationManager(HttpSecurity http,
+                        PasswordEncoder passwordEncoder) throws Exception {
+                AuthenticationManagerBuilder authenticationManagerBuilder = http
+                                .getSharedObject(AuthenticationManagerBuilder.class);
+                authenticationManagerBuilder.userDetailsService(userDetailsService)
+                                .passwordEncoder(passwordEncoder);
+                return authenticationManagerBuilder.build();
+        }
 
 }

--- a/back/src/main/java/com/jerem/mdd/controller/AuthController.java
+++ b/back/src/main/java/com/jerem/mdd/controller/AuthController.java
@@ -2,10 +2,8 @@ package com.jerem.mdd.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.jerem.mdd.dto.AuthResponseDto;
@@ -24,10 +22,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Controller class used for authentication purpose.
  * <p>
- * This class implements the authentication endpoints like login and register of the application.
+ * This class implements the authentication endpoints like login and register of
+ * the application.
  * </p>
  * <p>
- * - {@link DefaultAuthenticationService} service that process the user authentication -
+ * - {@link DefaultAuthenticationService} service that process the user
+ * authentication -
  * {@link UserManagementService} service used for business operations on users
  * </p>
  * 
@@ -47,20 +47,18 @@ public class AuthController {
 
     }
 
-
-
     /**
      * Login to the API.
      * 
      * <p>
-     * This method authenticates using POST parameters and return back a Json Web Token.
+     * This method authenticates using POST parameters and return back a Json Web
+     * Token.
      * 
      * @param {@link AuthRequestDto} the request DTO.
      * @return {@link AuthResponseDto} the response DTO.
      */
 
-    @Operation(summary = "Login to the API",
-            description = "This endpoint allows a user to authenticate by providing credentials. It returns a JWT token.")
+    @Operation(summary = "Login to the API", description = "This endpoint allows a user to authenticate by providing credentials. It returns a JWT token.")
     @ApiResponse(responseCode = "200", description = "Successful authentication, returns a token")
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @PostMapping("/login")
@@ -84,8 +82,7 @@ public class AuthController {
      * @param {@link RegisterRequestDto} the request DTO.
      * @return {@link UserSummaryDto} the response DTO.
      */
-    @Operation(summary = "Register to the API",
-            description = "This endpoint allows a user to register by providing registerRequest")
+    @Operation(summary = "Register to the API", description = "This endpoint allows a user to register by providing registerRequest")
     @ApiResponse(responseCode = "200", description = "Successful authentication, returns a token")
     @ApiResponse(responseCode = "409", description = "Email or username already exist")
     @PostMapping("/register")
@@ -93,6 +90,5 @@ public class AuthController {
         UserSummaryDto authResponse = registrationService.register(request);
         return ResponseEntity.ok(authResponse);
     }
-
 
 }

--- a/back/src/main/java/com/jerem/mdd/controller/PostController.java
+++ b/back/src/main/java/com/jerem/mdd/controller/PostController.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -97,20 +96,6 @@ public class PostController {
         }
 
 
-
-        /**
-         * Delete a post by its ID.
-         *
-         * @param postId Post ID.
-         */
-        @Operation(summary = "Delete post", description = "Delete a post by its ID.")
-        @ApiResponse(responseCode = "204", description = "Post deleted successfully")
-        @ApiResponse(responseCode = "404", description = "Post not found")
-        @DeleteMapping("/{postId}")
-        public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
-                postService.deletePost(postId);
-                return ResponseEntity.noContent().build();
-        }
 
         /**
          * Add a comment to a post.

--- a/back/src/main/java/com/jerem/mdd/controller/UserController.java
+++ b/back/src/main/java/com/jerem/mdd/controller/UserController.java
@@ -1,16 +1,22 @@
 package com.jerem.mdd.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.jerem.mdd.dto.UserDetailedDto;
+import com.jerem.mdd.dto.UserSummaryDto;
+import com.jerem.mdd.dto.UserUpdateRequestDto;
 import com.jerem.mdd.service.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,7 +37,6 @@ public class UserController {
 
     private final UserProfileService userProfileService;
 
-
     public UserController(UserProfileService userProfileService) {
 
         this.userProfileService = userProfileService;
@@ -51,5 +56,25 @@ public class UserController {
         return ResponseEntity.ok(userProfileService.getUserProfile());
     }
 
+    /**
+     * Update userProfile
+     *
+     * @param userUpdateRequestDto DTO containing updated user details.
+     * @return Updated user profile summary.
+     */
+    @Operation(summary = "Update user profile",
+            description = "Allows an authenticated user to update their profile information.")
+    @ApiResponse(responseCode = "202", description = "Profile updated successfully")
+    @ApiResponse(responseCode = "401", description = "Unauthorized")
+    @ApiResponse(responseCode = "404", description = "UserNotFound")
+    @ApiResponse(responseCode = "409", description = "Username or email already exists")
+    @ApiResponse(responseCode = "400", description = "Bad request invalid arguments")
+    @PutMapping
+    public ResponseEntity<UserSummaryDto> updateUserProfile(
+            @Valid @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(userProfileService.updateUserProfile(userUpdateRequestDto));
+
+    }
 
 }

--- a/back/src/main/java/com/jerem/mdd/dto/PostSummaryDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/PostSummaryDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
-
 @Data
 @Schema(description = "Response body containing the post.")
 public class PostSummaryDto {
@@ -21,6 +20,5 @@ public class PostSummaryDto {
     private TopicSummaryDto topic;
 
     private String content;
-
 
 }

--- a/back/src/main/java/com/jerem/mdd/dto/TopicDetailedDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/TopicDetailedDto.java
@@ -3,10 +3,12 @@ package com.jerem.mdd.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Schema(description = "Response body containing the topic.")
@@ -22,6 +24,5 @@ public class TopicDetailedDto extends TopicSummaryDto {
     private String description;
 
     private boolean subscribed;
-
 
 }

--- a/back/src/main/java/com/jerem/mdd/dto/UserUpdateRequestDto.java
+++ b/back/src/main/java/com/jerem/mdd/dto/UserUpdateRequestDto.java
@@ -1,0 +1,26 @@
+package com.jerem.mdd.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Request body for user update, may containing credentials.")
+@Data
+@NoArgsConstructor
+public class UserUpdateRequestDto {
+
+    @NotBlank
+    @Size(min = 3, max = 20)
+    private String username;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 12, max = 32)
+    private String password;
+}

--- a/back/src/main/java/com/jerem/mdd/model/AppUserDetails.java
+++ b/back/src/main/java/com/jerem/mdd/model/AppUserDetails.java
@@ -50,7 +50,7 @@ public class AppUserDetails implements UserDetails {
     }
 
     public Long getId() {
-        return Long.valueOf(user.getId().longValue());
+        return user.getId();
     }
 
     public String getEmail() {

--- a/back/src/main/java/com/jerem/mdd/model/Comment.java
+++ b/back/src/main/java/com/jerem/mdd/model/Comment.java
@@ -1,7 +1,6 @@
 package com.jerem.mdd.model;
 
 import java.util.Date;
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/back/src/main/java/com/jerem/mdd/model/Post.java
+++ b/back/src/main/java/com/jerem/mdd/model/Post.java
@@ -3,7 +3,6 @@ package com.jerem.mdd.model;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/back/src/main/java/com/jerem/mdd/model/Subscription.java
+++ b/back/src/main/java/com/jerem/mdd/model/Subscription.java
@@ -1,6 +1,5 @@
 package com.jerem.mdd.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/back/src/main/java/com/jerem/mdd/model/Topic.java
+++ b/back/src/main/java/com/jerem/mdd/model/Topic.java
@@ -2,7 +2,6 @@ package com.jerem.mdd.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/back/src/main/java/com/jerem/mdd/model/User.java
+++ b/back/src/main/java/com/jerem/mdd/model/User.java
@@ -2,7 +2,6 @@ package com.jerem.mdd.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/back/src/main/java/com/jerem/mdd/repository/UserRepository.java
+++ b/back/src/main/java/com/jerem/mdd/repository/UserRepository.java
@@ -40,4 +40,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findById(Long id);
 
+    boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
+
 }

--- a/back/src/main/java/com/jerem/mdd/service/AuthenticationService.java
+++ b/back/src/main/java/com/jerem/mdd/service/AuthenticationService.java
@@ -20,10 +20,7 @@ public interface AuthenticationService {
      */
     public AuthResponseDto authenticate(AuthRequestDto request) throws Exception;
 
-    public String getAuthenticatedUserEmail();
-
     public User getAuthenticatedUser();
-
 
 
 }

--- a/back/src/main/java/com/jerem/mdd/service/DefaultAuthenticationService.java
+++ b/back/src/main/java/com/jerem/mdd/service/DefaultAuthenticationService.java
@@ -1,6 +1,5 @@
 package com.jerem.mdd.service;
 
-import java.util.Optional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -9,6 +8,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.dto.AuthResponseDto;
 import com.jerem.mdd.exception.UserNotFoundException;
@@ -24,18 +24,23 @@ public class DefaultAuthenticationService implements AuthenticationService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
-    private final UserManagementService userManagementService;
-
 
     public DefaultAuthenticationService(AuthenticationManager authenticationManager,
-            JwtTokenProvider jwtTokenProvider, UserRepository userRepository,
-            UserManagementService userManagementService) {
+            JwtTokenProvider jwtTokenProvider, UserRepository userRepository) {
         this.authenticationManager = authenticationManager;
         this.jwtTokenProvider = jwtTokenProvider;
         this.userRepository = userRepository;
-        this.userManagementService = userManagementService;
+
     }
 
+    /**
+     * authenticate the user given their credentials in request
+     * <p>
+     * The user is retrieved using identifier which can be email or username
+     * </p>
+     * 
+     * @return an {@link AuthResponseDto} the response containing de token
+     */
     public AuthResponseDto authenticate(AuthRequestDto request) throws Exception {
         User user = userRepository.findByEmail(request.getIdentifier())
                 .orElseGet(() -> userRepository.findByUsername(request.getIdentifier()).orElseThrow(
@@ -54,38 +59,34 @@ public class DefaultAuthenticationService implements AuthenticationService {
             throw new AuthenticationServiceException("Authentication failed", e);
         }
 
-
     }
 
     /**
-     * Retrieves the email of the currently authenticated user.
+     * Retrieves the authenticated user.
      * <p>
-     * This method accesses the {@link SecurityContextHolder} to obtain the authentication details.
+     * This method accesses the {@link SecurityContextHolder} to obtain the authentication. Then it
+     * retrieves the claim id from Jwt
      * </p>
      * 
-     * @return an {@link Optional} containing the authenticated user's email, or empty if no user is
-     *         authenticated
+     * @return an {@link User} the authenticated user
      */
     @Override
-    public String getAuthenticatedUserEmail() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication != null && authentication.isAuthenticated()) {
-
-            return authentication.getName();
-
-        } else {
-
-            throw new UsernameNotFoundException("User not authenticated");
-        }
-    }
-
-    @Override
     public User getAuthenticatedUser() {
-        return userManagementService.getUserEntityByEmail(getAuthenticatedUserEmail())
-                .orElseThrow(() -> new UserNotFoundException("User not authenticated"));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof Jwt) {
+                Jwt jwt = (Jwt) principal;
+                Long userId = jwt.getClaim("id");
+                log.debug("" + jwt.getClaim("id"));
+                log.debug(jwt.getClaim("username"));
+                log.debug(jwt.getClaim("email"));
+
+                return userRepository.findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException("User not found"));
+            }
+        }
+        throw new UserNotFoundException("User not found");
     }
-
-
 
 }

--- a/back/src/main/java/com/jerem/mdd/service/DefaultRegistrationService.java
+++ b/back/src/main/java/com/jerem/mdd/service/DefaultRegistrationService.java
@@ -4,7 +4,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.model.User;
 import com.jerem.mdd.repository.UserRepository;
-
 import com.jerem.mdd.dto.RegisterRequestDto;
 import com.jerem.mdd.dto.UserSummaryDto;
 import com.jerem.mdd.exception.EmailAlreadyExistException;
@@ -24,7 +23,6 @@ public class DefaultRegistrationService implements RegistrationService {
         this.userMapper = userMapper;
         this.passwordEncoder = passwordEncoder;
         this.userRepository = userRepository;
-
     }
 
     @Override

--- a/back/src/main/java/com/jerem/mdd/service/DefaultUserManagementService.java
+++ b/back/src/main/java/com/jerem/mdd/service/DefaultUserManagementService.java
@@ -1,7 +1,6 @@
 package com.jerem.mdd.service;
 
 import java.util.Optional;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.model.AppUserDetails;
@@ -39,17 +38,6 @@ public class DefaultUserManagementService implements UserManagementService {
     @Override
     public AppUserDetails createUser(String email, String plainPassword, String username) {
 
-        // if (isEmailAlreadyUsed(email) )) {
-        // throw new UserAlreadyUsedException("Email '" + email + "' is already present in
-        // database.",
-        // "DefaultUserManagementService.createUser");
-        // }
-        // if (isUsernameAlreadyUsed(username) )) {
-        // throw new EmailAlreadyUsedException("User '" + username + "' is already present in
-        // database.",
-        // "DefaultUserManagementService.createUser");
-        // }
-
 
         User user = new User();
         user.setEmail(email);
@@ -59,18 +47,6 @@ public class DefaultUserManagementService implements UserManagementService {
         userRepository.save(user);
 
         return new AppUserDetails(user);
-    }
-
-    @Override
-    public UserDetails getUserbyEmail(String email) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getUserbyEmail'");
-    }
-
-    @Override
-    public UserDetails getUserbyUsername(String username) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getUserbyUsername'");
     }
 
     @Override
@@ -93,6 +69,7 @@ public class DefaultUserManagementService implements UserManagementService {
     public Optional<User> getUserEntityByEmail(String email) {
         return userRepository.findByEmail(email);
     }
+
 
 
 }

--- a/back/src/main/java/com/jerem/mdd/service/PostService.java
+++ b/back/src/main/java/com/jerem/mdd/service/PostService.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.Date;
 
 import org.springframework.data.domain.Page;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.dto.CommentRequestDto;
@@ -12,6 +13,7 @@ import com.jerem.mdd.dto.PostRequestDto;
 import com.jerem.mdd.dto.PostSummaryDto;
 import com.jerem.mdd.mapper.PostMapper;
 import com.jerem.mdd.model.Comment;
+
 import com.jerem.mdd.model.Post;
 import com.jerem.mdd.model.Topic;
 import com.jerem.mdd.model.User;
@@ -24,18 +26,16 @@ import com.jerem.mdd.exception.*;
 public class PostService {
 
     private final AuthenticationService authenticationService;
-    private final UserManagementService userManagementService;
     private final PostMapper postMapper;
     private final PostRepository postRepository;
     private final TopicRepository topicRepository;
     private final CommentRepository commentRepository;
 
     public PostService(AuthenticationService authenticationService,
-            UserManagementService userManagementService, PostMapper postMapper,
+            PostMapper postMapper,
             PostRepository postRepository, TopicRepository topicRepository,
             CommentRepository commentRepository) {
         this.authenticationService = authenticationService;
-        this.userManagementService = userManagementService;
         this.postMapper = postMapper;
         this.postRepository = postRepository;
         this.topicRepository = topicRepository;
@@ -43,11 +43,8 @@ public class PostService {
     }
 
     public PostSummaryDto createPost(PostRequestDto postRequestDto) {
-        String authenticatedUserEmail = authenticationService.getAuthenticatedUserEmail();
 
-        User authenticatedUser = userManagementService.getUserEntityByEmail(authenticatedUserEmail)
-                .orElseThrow(() -> new UserNotFoundException("User not found",
-                        "PostService.createPost"));
+        User authenticatedUser = authenticationService.getAuthenticatedUser();
 
         Topic topic = topicRepository.findById(postRequestDto.getTopicId()).orElseThrow(
                 () -> new TopicNotFoundException("Topic not found", "PostService.createPost"));
@@ -59,11 +56,8 @@ public class PostService {
         post.setTitle(postRequestDto.getTitle());
         post.setContent(postRequestDto.getContent());
 
-
         postRepository.save(post);
         return postMapper.toDto(post);
-
-
 
     }
 
@@ -80,22 +74,11 @@ public class PostService {
         return postMapper.toDetailedDto(post);
     }
 
-    public void deletePost(Long postId) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'deletePost'");
-    }
-
 
     public PostDetailedDto addPost(Long postId, CommentRequestDto commentRequest) {
-        String authenticatedUserEmail = authenticationService.getAuthenticatedUserEmail();
-
-        User authenticatedUser = userManagementService.getUserEntityByEmail(authenticatedUserEmail)
-                .orElseThrow(() -> new UserNotFoundException("User not found",
-                        "PostService.createPost"));
-
+        User authenticatedUser = authenticationService.getAuthenticatedUser();
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new PostNotFoundException("Post not found", "PostService.getAllPosts"));
-
 
         Comment comment = new Comment();
         comment.setAuthor(authenticatedUser);
@@ -105,8 +88,6 @@ public class PostService {
 
         commentRepository.save(comment);
         return postMapper.toDetailedDto(post);
-
-
 
     }
 

--- a/back/src/main/java/com/jerem/mdd/service/SubscriptionService.java
+++ b/back/src/main/java/com/jerem/mdd/service/SubscriptionService.java
@@ -8,14 +8,12 @@ import com.jerem.mdd.dto.SubscriptionDto;
 import com.jerem.mdd.exception.SubscriptionAlreadyExistException;
 import com.jerem.mdd.exception.SubscriptionNotFoundException;
 import com.jerem.mdd.exception.TopicNotFoundException;
-import com.jerem.mdd.exception.UserNotFoundException;
 import com.jerem.mdd.mapper.SubscriptionMapper;
 import com.jerem.mdd.model.Subscription;
 import com.jerem.mdd.model.Topic;
 import com.jerem.mdd.model.User;
 import com.jerem.mdd.repository.SubscriptionRepository;
 import com.jerem.mdd.repository.TopicRepository;
-import com.jerem.mdd.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 
 
@@ -24,17 +22,15 @@ public class SubscriptionService {
         private final SubscriptionRepository subscriptionRepository;
         private final AuthenticationService authenticationService;
         private final TopicRepository topicRepository;
-        private final UserRepository userRepository;
         private final SubscriptionMapper subscriptionMapper;
 
         public SubscriptionService(SubscriptionRepository subscriptionRepository,
                         AuthenticationService authenticationService,
-                        TopicRepository topicRepository, UserRepository userRepository,
+                        TopicRepository topicRepository,
                         SubscriptionMapper subscriptionMapper) {
                 this.subscriptionRepository = subscriptionRepository;
                 this.authenticationService = authenticationService;
                 this.topicRepository = topicRepository;
-                this.userRepository = userRepository;
                 this.subscriptionMapper = subscriptionMapper;
         }
 
@@ -47,10 +43,7 @@ public class SubscriptionService {
 
 
         public SubscriptionDto subscribe(String topicId) {
-                String username = authenticationService.getAuthenticatedUserEmail();
-                User user = userRepository.findByEmail(username)
-                                .orElseThrow(() -> new UserNotFoundException("User not found",
-                                                "SubscriptionService.subscribe"));
+                User user = authenticationService.getAuthenticatedUser();
 
                 Topic topic = topicRepository.findById(Long.parseLong(topicId))
                                 .orElseThrow(() -> new TopicNotFoundException("Topic not found",
@@ -76,11 +69,7 @@ public class SubscriptionService {
          * @throws EntityNotFoundException if the subscription does not exist.
          */
         public void unsubscribe(String topicId) {
-                String username = authenticationService.getAuthenticatedUserEmail();
-
-                User user = userRepository.findByEmail(username)
-                                .orElseThrow(() -> new UserNotFoundException("User not found",
-                                                "SubscriptionService.unsubscribe"));
+                User user = authenticationService.getAuthenticatedUser();
 
                 Topic topic = topicRepository.findById(Long.parseLong(topicId))
                                 .orElseThrow(() -> new TopicNotFoundException("Topic not found",
@@ -107,11 +96,7 @@ public class SubscriptionService {
          * @throws UsernameNotFoundException if user not found in repository
          */
         public List<SubscriptionDetailedDto> findAll() {
-                String username = authenticationService.getAuthenticatedUserEmail();
-                User user = userRepository.findByEmail(username)
-                                .orElseThrow(() -> new UserNotFoundException("User not found",
-                                                "SubscriptionService.findAll"));
-
+                User user = authenticationService.getAuthenticatedUser();
                 List<Subscription> subscriptions =
                                 subscriptionRepository.findByUserWithTopics(user);
                 return subscriptionMapper.toDetailedDto(subscriptions);

--- a/back/src/main/java/com/jerem/mdd/service/TopicService.java
+++ b/back/src/main/java/com/jerem/mdd/service/TopicService.java
@@ -3,18 +3,13 @@
 package com.jerem.mdd.service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.dto.TopicDetailedDto;
-import com.jerem.mdd.exception.UserNotFoundException;
 import com.jerem.mdd.mapper.TopicMapper;
-import com.jerem.mdd.model.Subscription;
 import com.jerem.mdd.model.Topic;
 import com.jerem.mdd.model.User;
 import com.jerem.mdd.repository.TopicRepository;
-
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TopicService {
 
-    private final UserManagementService userManagementService;
 
     private final SubscriptionService subscriptionService;
     private final TopicRepository topicRepository;
@@ -30,13 +24,11 @@ public class TopicService {
     private final AuthenticationService authenticationService;
 
     public TopicService(TopicRepository topicRepository, TopicMapper topicMapper,
-            AuthenticationService authenticationService, SubscriptionService subscriptionService,
-            UserManagementService userManagementService) {
+            AuthenticationService authenticationService, SubscriptionService subscriptionService) {
         this.topicRepository = topicRepository;
         this.topicMapper = topicMapper;
         this.authenticationService = authenticationService;
         this.subscriptionService = subscriptionService;
-        this.userManagementService = userManagementService;
     }
 
     public Topic getTopic(@NonNull Long id) {
@@ -47,22 +39,7 @@ public class TopicService {
     public List<TopicDetailedDto> findAll() {
         List<Topic> topics = topicRepository.findAll();
 
-
-        String authenticatedUserEmail = authenticationService.getAuthenticatedUserEmail();
-
-        User authenticatedUser = userManagementService.getUserEntityByEmail(authenticatedUserEmail)
-                .orElseThrow(() -> new UserNotFoundException("User not found",
-                        "PostService.createPost"));
-
-        // Set<Long> subscriptionsTopicIds =
-        // subscriptionService.getSubscriptionsByUser(authenticatedUser).stream()
-        // .map(sub -> sub.getTopic().getId()).collect(Collectors.toSet());
-
-        log.debug("FindAllTopics: ");
-        log.debug("User: " + authenticatedUser.getUsername());
-        // log.debug("subscriptionTopicsIds " + subscriptionsTopicIds);
-
-
+        User authenticatedUser = authenticationService.getAuthenticatedUser();
 
         return topics.stream().map(topic -> {
             TopicDetailedDto topicDto = topicMapper.toDto(topic);

--- a/back/src/main/java/com/jerem/mdd/service/UserManagementService.java
+++ b/back/src/main/java/com/jerem/mdd/service/UserManagementService.java
@@ -1,6 +1,5 @@
 package com.jerem.mdd.service;
 
-import com.jerem.mdd.model.Topic;
 import com.jerem.mdd.model.User;
 import java.util.Optional;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -29,23 +28,6 @@ public interface UserManagementService {
     public UserDetails createUser(String email, String plainPassword, String username);
 
 
-    /**
-     * Retrieves a {@link UserDetails} object by email. This object should be cast to its
-     * implementation.
-     * 
-     * @param {@link String} the email.
-     * @return a {@link UserDetails}
-     */
-    public UserDetails getUserbyEmail(String email);
-
-    /**
-     * Retrieves a {@link UserDetails} object by username. This object should be cast to its
-     * implementation.
-     * 
-     * @param {@link String} the username.
-     * @return a {@link UserDetails}
-     */
-    public UserDetails getUserbyUsername(String username);
 
     /**
      * Return true if the email is already present in the Database.

--- a/back/src/main/java/com/jerem/mdd/service/UserProfileService.java
+++ b/back/src/main/java/com/jerem/mdd/service/UserProfileService.java
@@ -1,47 +1,98 @@
 package com.jerem.mdd.service;
 
-import java.util.Optional;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import com.jerem.mdd.dto.UserDetailedDto;
+import com.jerem.mdd.dto.UserUpdateRequestDto;
+import com.jerem.mdd.exception.EmailAlreadyExistException;
+import com.jerem.mdd.exception.UserNotFoundException;
+import com.jerem.mdd.exception.UsernameAlreadyExistException;
 import com.jerem.mdd.mapper.UserMapper;
 import com.jerem.mdd.model.User;
+import com.jerem.mdd.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 
 
+
+/**
+ * Service class for user profile operations, including updating and retrieving profile information.
+ * <p>
+ * This service focuses on actions related to the authenticated user's profile and should not
+ * utilize any implementation of {@link UserManagementService} to maintain a strict separation of
+ * responsibilities.
+ * </p>
+ */
 @Service
 @Slf4j
 public class UserProfileService {
 
 
-    private final UserManagementService userManagementService;
+    private final UserRepository userRepository;
     private final AuthenticationService authenticationService;
+    private final PasswordEncoder passwordEncoder;
 
     private final UserMapper userMapper;
 
 
-    public UserProfileService(UserManagementService userManagementService,
-            AuthenticationService authenticationService, UserMapper userMapper) {
-        this.userManagementService = userManagementService;
+    public UserProfileService(UserRepository userRepository,
+            AuthenticationService authenticationService, UserMapper userMapper,
+            PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
         this.authenticationService = authenticationService;
         this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
+
     }
 
 
     public UserDetailedDto getUserProfile() {
 
-        String authenticatedUserEmail = authenticationService.getAuthenticatedUserEmail();
+        return userMapper.toUserProfileDto(getAuthenticatedUser());
+    }
 
-        Optional<User> authenticatedUser =
-                userManagementService.getUserEntityByEmail(authenticatedUserEmail);
 
-        if (authenticatedUser.isPresent()) {
 
-            return userMapper.toUserProfileDto(authenticatedUser.get());
+    public UserDetailedDto updateUserProfile(UserUpdateRequestDto userUpdateRequestDto) {
+        User authenticatedUser = getAuthenticatedUser();
 
-        } else
-            throw new UsernameNotFoundException("No authenticated user found");
+
+        if (!userUpdateRequestDto.getEmail().equals(authenticatedUser.getEmail())
+                && userRepository.existsByEmail(userUpdateRequestDto.getEmail())) {
+            throw new EmailAlreadyExistException("Email already exists",
+                    "UserProfileService.updateUserProfile");
+        }
+
+        if (!userUpdateRequestDto.getUsername().equals(authenticatedUser.getUsername())
+                && userRepository.existsByUsername(userUpdateRequestDto.getUsername())) {
+            throw new UsernameAlreadyExistException("Username already exists",
+                    "UserProfileService.updateUserProfile");
+        }
+
+
+
+        authenticatedUser.setEmail(userUpdateRequestDto.getEmail());
+        authenticatedUser.setUsername(userUpdateRequestDto.getUsername());
+
+
+        if (!passwordEncoder.matches(userUpdateRequestDto.getPassword(),
+                authenticatedUser.getPassword())) {
+            authenticatedUser
+                    .setPassword(passwordEncoder.encode(userUpdateRequestDto.getPassword()));
+        }
+
+        userRepository.save(authenticatedUser);
+
+        return userMapper.toUserProfileDto(authenticatedUser);
 
     }
+
+    private User getAuthenticatedUser() {
+        String authenticatedUserEmail = authenticationService.getAuthenticatedUser().getEmail();
+
+        return userRepository.findByEmail(authenticatedUserEmail)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+    }
+
+
 
 }


### PR DESCRIPTION
Add user update support and clarify service responsibilities

- Add UserUpdateRequestDto, identical in structure to RegisterRequestDto, but kept separate for semantic clarity.
- Refactor UserProfileService to use UserRepository directly instead of UserManagementService: UserManagementService will handle business operations on users, while UserProfileService will be kept focused on authenticated user profile actions.

Add the Endpoint to the RestController
- Add to UserController a @PutMapping endpoint for the profile update

Manage the update problem:

Because update method can now update the email or username and the user can authenticate with one or the other, we should manage the update of the security context. Another method is to encode the user id into the jwt claimset. This id never change.

- change method AuthenticationService.getAuthenticatedUser used to retrieve authenticated User. The id is extract from claims and used to get the user from repository instead of using authentication.getName()
- update DefaultJwtTokenProvider to include id claim into jwt token during token generation

Refactor:

Replace AuthenticationService.getAuthenticatedUser and AuthenticationService.getAuthenticatedUserEmail by the new AuthenticationService.getAuthenticatedUser => simplification in services by replacing (getAuthenticatedUserEmail + getAuthenticatedUser with UsermanagementService)

clean some comments, debug lines and linting